### PR TITLE
feat: Use `IF NOT EXISTS`  when creating migrations table

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -69,7 +69,7 @@ export class SpannerMigration {
     await this.db
       .createTable(
         `
-        CREATE TABLE ${this.migrationsTable} (
+        CREATE TABLE IF NOT EXISTS ${this.migrationsTable} (
           id          STRING(64) NOT NULL,
           success     BOOL NOT NULL,
           appliedAt   TIMESTAMP NOT NULL,


### PR DESCRIPTION
Currently, Spanner will produce a schema update error when it fails to create the `migrations_log` table on each run (since it already exists at that point).

We can utilise the `IF NOT EXISTS` parameter on the `CREATE TABLE` statement, which then results in no error if the table already exists.

https://cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#create_table

