### PR TITLE
fix: treat search indices as DDL

### DIFF
--- a/src/loader/parse-migrations.ts
+++ b/src/loader/parse-migrations.ts
@@ -25,6 +25,9 @@ const ddlStatementsPatterns: RegExp[] = [
   /^alter\s+index/i,
   /^drop\s+index/i,
 
+  // CREATE SEARCH INDEX [ IF NOT EXISTS ] index_name
+  /^create\s+search\s+index/i,
+
   // view statements
   /^create\s+view/i,
   /^create\s+or\s+replace\s+view/i,

--- a/src/loader/parse-migrations.ts
+++ b/src/loader/parse-migrations.ts
@@ -27,7 +27,10 @@ const ddlStatementsPatterns: RegExp[] = [
 
   // CREATE SEARCH INDEX [ IF NOT EXISTS ] index_name
   /^create\s+search\s+index/i,
-
+  // ALTER SEARCH INDEX index_name ...
+  /^alter\s+search\s+index/i,
+  // DROP SEARCH INDEX [ IF EXISTS ] index_name
+  /^drop\s+search\s+index/i,
   // view statements
   /^create\s+view/i,
   /^create\s+or\s+replace\s+view/i,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recognize Spanner search-index DDL statements: CREATE SEARCH INDEX, ALTER SEARCH INDEX, and DROP SEARCH INDEX.
  * Classify these statements as DDL (not DML), restoring consistent single-statement-type validation for migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->